### PR TITLE
Add secret type to secret_from_dict()

### DIFF
--- a/secret/Tiltfile
+++ b/secret/Tiltfile
@@ -59,12 +59,14 @@ def secret_yaml_generic(name, namespace="", from_file=None, secret_type=None, fr
   args.extend(["-o=yaml", "--dry-run=client"])
   return local(args, quiet=True, echo_off=True)
 
-def secret_from_dict(name, namespace="", inputs={}):
+def secret_from_dict(name, namespace="", inputs={}, secret_type=None):
     """Returns YAML for a generic secret
     Args:
         name: The configmap name.
         namespace: The namespace.
         inputs: A dict of keys and values to use. Nesting is not supported
+        secret_type (optional): Specify the type of the secret
+          Example: 'kubernetes.io/dockerconfigjson'
     Returns:
         The secret YAML as a blob
     """
@@ -86,6 +88,12 @@ def secret_from_dict(name, namespace="", inputs={}):
     for k,v in inputs.items():
         args.extend(["--from-literal", "%s=%s" % (k,v)])
 
+    if secret_type:
+      if type(secret_type) == "string":
+        args.extend(["--type", secret_type])
+      else:
+        fail("Bad secret_type argument: %s" % secret_type)
+        
     args.extend(["-o=yaml", "--dry-run=client"])
     return local(args, quiet=True, echo_off=True)
 


### PR DESCRIPTION
In order to perform an operation like this kubectl command:

```
kubectl create secret docker-registry artifact-registry \
 --docker-server=host.somedomain \
 --docker-username=_json_key \
 --docker-password="$(cat service-account.json)" \
 --docker-email=email@email.com
```

This does not work with `secret_yaml_generic()`

And `secret_from_dict()` would work if you could pass the secret type, hence this merge request.